### PR TITLE
[fix] Effectively disable copy threshold during socket test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 nose
-pyzmq<17.0.0
+pyzmq
 simplejson


### PR DESCRIPTION
- requirements.txt: Lift restriction on pyzmq<17.0.0

- rumrunner.py: pyzmq>17.0.0 introduces a new attribute .copy_threshold
which forces copy=True regardless of what is set in send() for messages
smaller than the threshold. This would disable tracking on the
test_socket_writable message. This checks for the new attribute and sets
the .copy_threshold to 0 for the socket writable test then resets it to
the default value after.

Tested: With Python 2.7/3.7 with pyzmq 18.0.1 and pyzmq 16.0.4